### PR TITLE
review_rtt_odelalleau_feature

### DIFF
--- a/quic/state/QuicStateFunctions.cpp
+++ b/quic/state/QuicStateFunctions.cpp
@@ -45,6 +45,8 @@ void updateRtt(
     std::chrono::microseconds ackDelay) {
   std::chrono::microseconds minRtt = timeMin(conn.lossState.mrtt, rttSample);
   conn.lossState.maxAckDelay = timeMax(conn.lossState.maxAckDelay, ackDelay);
+  conn.lossState.lastAckDelay = ackDelay;
+  conn.lossState.ldrtt = rttSample;
   bool shouldUseAckDelay = (rttSample > ackDelay) &&
       (rttSample > minRtt + ackDelay || conn.lossState.mrtt == kDefaultMinRtt);
   if (shouldUseAckDelay) {

--- a/quic/state/StateData.h
+++ b/quic/state/StateData.h
@@ -416,12 +416,18 @@ struct LossState {
   EnumArray<PacketNumberSpace, folly::Optional<TimePoint>> lossTimes;
   // Max ack delay received from peer
   std::chrono::microseconds maxAckDelay{0us};
+  // Latest ack delay received from peer
+  std::chrono::microseconds lastAckDelay{0us};
   // minimum rtt. AckDelay isn't excluded from this.
   std::chrono::microseconds mrtt{kDefaultMinRtt};
   // Smooth rtt
   std::chrono::microseconds srtt{0us};
   // Latest rtt
   std::chrono::microseconds lrtt{0us};
+  // Latest rtt *including* ack delay
+  // (it is not just equal to `lrtt + lastAckDelay` because `lrtt` does not
+  // always remove the ack delay)
+  std::chrono::microseconds ldrtt{0us};
   // Rtt var
   std::chrono::microseconds rttvar{0us};
   // The sent time of the latest acked packet


### PR DESCRIPTION
This is to make sure we can recover statistics on ACK delay and full RTT (including ACK delay), which wasn't possible before in all situations (due to the current logic in mvfst regarding when to subtract ACK delay from RTT samples).